### PR TITLE
修改一个翻译上的错误。

### DIFF
--- a/chap2.tex
+++ b/chap2.tex
@@ -189,7 +189,7 @@ t_j$。给个例子，
 
 \gls*{bp}其实是对\gls*{weight}和\gls*{bias}变化影响代价函数过程的理解。最终极的
 含义其实就是计算偏导数 $\partial C/\partial w_{jk}^l$ 和 $\partial C/\partial
-b_j^l$。但是为了计算这些值，我们首先引入一个中间量，$\delta_j^l$，这个我们称为在
+b_j^l$。但是为了计算这些值，我们首先引入一个中间量，$\delta_j^l$，我们用之来引出在
 $l^{th}$ 层第 $j^{th}$ 个神经元上的\textbf{\gls{error}}。
 
 \gls*{bp}将给出计算误差 $\delta_j^l$ 的流程，然后将其关联到计算 $\partial


### PR DESCRIPTION
 原文：
But to compute those, we first introduce an intermediate quantity, δlj, which we call the error in the jth neuron in the lth layer. 

这里翻译有问题，这个变量不是被称为误差，而是用来调用误差。
翻译成 用来引出这个神经元上的误差。 比较合适。